### PR TITLE
hot fix for github provider for nullable names

### DIFF
--- a/src/Controllers/SocialmentController.php
+++ b/src/Controllers/SocialmentController.php
@@ -59,7 +59,7 @@ class SocialmentController extends Controller
                 // Create a new user if one doesn't exist
                 $user = $userModel::where('email', $socialUser->getEmail())->first()
                     ?? $userModel::create([
-                        'name' => $socialUser->getName(),
+                        'name' => $socialUser->getName() ?? $socialUser->getNickname(),
                         'email' => $socialUser->getEmail(),
                     ]);
 


### PR DESCRIPTION
apparently, new github accounts don't have `name`, so it always returns null. unless the user sets one